### PR TITLE
Changes to StickyHeaders

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (c) 2011, Matteo Lissandrini - web@kuzeko.com
 Copyright (c) 2011, Ragnis Armus
+Copyright (c) 2013, Andrew Kester
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Inspired by http://jsfiddle.net/trepmal/e7GN8/
 
 ## Requirements
 
-Developed and tested with [jQuery version 1.6.2](http://code.jquery.com/jquery-1.6.2.js)
+Developed and tested with [jQuery version 1.9.1](http://code.jquery.com/jquery-1.9.1.js)
 
 
 

--- a/src/jquery.stickyheaders.css
+++ b/src/jquery.stickyheaders.css
@@ -30,29 +30,11 @@
     background-color: #ffe;
     color: #039;
     
-    /* css 3 */
-    background-image: -webkit-gradient(linear, left top, left bottom, from(#ffe), to(#ffc));
-    background-image: -webkit-linear-gradient(top, #ffe, #ffc);
-    background-image: -moz-linear-gradient(top, #ffe, #ffc);
-    background-image: -o-linear-gradient(top, #ffe, #ffc);
-    background-image: -ms-linear-gradient(top, #ffe, #ffc);
-    background-image: linear-gradient(top, #ffe, #ffc);
-    -webkit-box-shadow: 0px 0px 10px #111;
-    -moz-box-shadow: 0px 0px 10px #111;
     box-shadow: 0px 0px 10px #111; 
 }
  
  
 #standing .stand {
-    border-bottom: 1px dotted #e0e0a0;
-    font-size: 12px;
-    font-style: normal;
-    line-height: 24px;
-    min-height: 24px;  
-    padding: 2px 0px;  
-    text-align: center;
-    
-    /* css 3 */
-    text-shadow: 0 1px 1px #fff;
+
 }
  

--- a/src/jquery.stickyheaders.js
+++ b/src/jquery.stickyheaders.js
@@ -1,6 +1,8 @@
 /*!
  * Copyright 2011 Matteo Lissandrini, Ragnis Armus
  * Licensed under the BSD 3-clause license.
+ * Modified by Andrew Kester.  Those changes (marked) are copyright 2013 and
+ * released under GNU-GPL v3
  */
 
 (function ($)
@@ -30,7 +32,14 @@
 			{
 				var $ref = $('#multisticky_' + id);
 
-				if ((dist + $standing.height() - 20)  >= $ref.data('from-top'))
+				var $next = $('#multisticky_' + (id + 1));
+				var $prev = $('#multisticky_' + (id - 1));
+				
+				var currentdist = dist + $standing.height() - 20
+
+				if ((currentdist  >= $ref.data('from-top'))
+						&& ( currentdist > $prev.data('from-top') - 20)
+						&& ( currentdist < $next.data('from-top') - 20))
 				{
 					$ref.slideDown();
 				}

--- a/src/jquery.stickyheaders.js
+++ b/src/jquery.stickyheaders.js
@@ -1,8 +1,7 @@
 /*!
  * Copyright 2011 Matteo Lissandrini, Ragnis Armus
+ * Copyright 2013 Andrew Kester (some changes).
  * Licensed under the BSD 3-clause license.
- * Modified by Andrew Kester.  Those changes (marked) are copyright 2013 and
- * released under GNU-GPL v3
  */
 
 (function ($)
@@ -31,7 +30,9 @@
 			self.each(function (id, element)
 			{
 				var $ref = $('#multisticky_' + id);
-
+				/* Changes to prevent multiple boxes from stacking in the
+				 * page
+				 */
 				var $next = $('#multisticky_' + (id + 1));
 				var $prev = $('#multisticky_' + (id - 1));
 				
@@ -41,6 +42,7 @@
 						&& ( currentdist > $prev.data('from-top') - 20)
 						&& ( currentdist < $next.data('from-top') - 20))
 				{
+				/* End of changes */
 					$ref.slideDown();
 				}
 				else


### PR DESCRIPTION
Hello,
I've made some changes to your StickyHeaders library to prevent multiple headers from stacking on each other and to allow page formatting to be used.  This way the page can have nicely formatted div headers that carry into the sticky headers.

Also, I've tested it with JQuery 1.9.1 and it works fine, I've updated the README to reflect that.

The changes were for a specific site's formatting, but I thought they could be useful to another site.  My JavaScript is not the best, but this code does function.

Thanks,
Andrew Kester
